### PR TITLE
add aws_eks_access_entry

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -86,7 +86,6 @@ resource "aws_iam_role_policy_attachment" "controller_role" {
 }
 
 resource "aws_eks_access_entry" "node_role" {
-  count         = var.create_eks_access_entry ? 1 : 0
   cluster_name  = var.cluster_name
   principal_arn = aws_iam_role.node_role.arn
   type          = "EC2_LINUX"

--- a/variables.tf
+++ b/variables.tf
@@ -53,9 +53,3 @@ variable "kubernetes_version" {
   default     = null
   description = "Kubernetes version to use for the node group. Required if ami_type is set"
 }
-
-variable "create_eks_access_entry" {
-  type        = bool
-  default     = false
-  description = "Create EKS access entry for the node role. Usually done by the Harness SaaS"
-}


### PR DESCRIPTION
module is missing access entry to allow nodes provisioned by the orchestrator to join the cluster

https://developer.harness.io/docs/cloud-cost-management/use-ccm-cost-optimization/cluster-orchestrator/setting-up-co/