### PR TITLE
refactor: move to AL2023 ARM as default ami type

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| ami\_type | Type of AMI to use for the node group | `string` | `"AL2_x86_64"` | no |
+| ami\_type | Type of AMI to use for the node group | `string` | `"AL2023_ARM_64_STANDARD"` | no |
 | ccm\_k8s\_connector\_id | harness ccm kubernetes connector for the cluster | `string` | n/a | yes |
 | cluster\_amis | AMIs used in your EKS cluster; If passed will be tagged with required orchestrator labels | `list(string)` | `[]` | no |
 | cluster\_endpoint | EKS cluster endpoint | `string` | n/a | yes |

--- a/variables.tf
+++ b/variables.tf
@@ -45,7 +45,7 @@ variable "node_role_policies" {
 
 variable "ami_type" {
   type        = string
-  default     = "AL2_x86_64"
+  default     = "AL2023_ARM_64_STANDARD"
   description = "Type of AMI to use for the node group"
 }
 


### PR DESCRIPTION
AL2 is being phased out and AL2023 based AMIs are becoming standard. So adjusting the default value for `ami_type` to align.